### PR TITLE
Add registration endpoint and CSRF allowlist

### DIFF
--- a/src/common/middleware/csrf.middleware.ts
+++ b/src/common/middleware/csrf.middleware.ts
@@ -5,6 +5,17 @@ const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 export const csrfMiddleware: RequestHandler = (req, res, next) => {
   try {
     if (!MUTATING_METHODS.has(req.method)) return next();
+
+    const path = req.path || req.originalUrl || '';
+    const ALLOWLIST = [
+      '/api/auth/login',
+      '/api/auth/register',
+      '/api/auth/refresh',
+      '/api/auth/logout',
+      '/api/auth/2fa/verify',
+    ];
+    if (ALLOWLIST.some((route) => path.startsWith(route))) return next();
+
     const cookieName = process.env.AUTH_CSRF_COOKIE_NAME || 'sopy-csrf';
     const headerToken =
       typeof req.headers['x-csrf-token'] === 'string'

--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import { Response } from 'express';
 import { randomBytes } from 'crypto';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
 import { twoFactorService } from '../../common/security/twofactor.service';
 import { loginAttemptsService } from '../../common/security/login-attempts.service';
 
@@ -36,11 +37,11 @@ export class AuthController {
       Number(process.env.AUTH_REFRESH_TOKEN_MAX_AGE_MS) ||
       7 * 24 * 60 * 60 * 1000;
     const accessCookieName = process.env.AUTH_COOKIE_NAME || 'sopy-auth-token';
+    const sameSite = (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax';
     res.cookie(accessCookieName, accessToken, {
       httpOnly: true,
-      secure,
-      sameSite:
-        (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax',
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
       maxAge: accessMaxAge,
       path: '/',
     });
@@ -48,13 +49,62 @@ export class AuthController {
       process.env.AUTH_REFRESH_COOKIE_NAME || 'sopy-refresh-token';
     res.cookie(refreshCookieNameEnv, refreshToken, {
       httpOnly: true,
-      secure,
-      sameSite:
-        (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax',
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
       maxAge: refreshMaxAge,
       path: '/',
     });
     return { success: true };
+  }
+
+  @Post('register')
+  @HttpCode(201)
+  async register(
+    @Body() body: RegisterDto,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const { accessToken, refreshToken, user } = await this.authService.register(
+      body,
+    );
+
+    const secure = process.env.NODE_ENV === 'production';
+    const accessMaxAge =
+      Number(process.env.AUTH_ACCESS_TOKEN_MAX_AGE_MS) || 15 * 60 * 1000;
+    const refreshMaxAge =
+      Number(process.env.AUTH_REFRESH_TOKEN_MAX_AGE_MS) ||
+      7 * 24 * 60 * 60 * 1000;
+
+    const accessCookieName = process.env.AUTH_COOKIE_NAME || 'sopy-auth-token';
+    const sameSite = (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax';
+    res.cookie(accessCookieName, accessToken, {
+      httpOnly: true,
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
+      maxAge: accessMaxAge,
+      path: '/',
+    });
+
+    const refreshCookieName =
+      process.env.AUTH_REFRESH_COOKIE_NAME || 'sopy-refresh-token';
+    res.cookie(refreshCookieName, refreshToken, {
+      httpOnly: true,
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
+      maxAge: refreshMaxAge,
+      path: '/',
+    });
+
+    const csrfCookieName = process.env.AUTH_CSRF_COOKIE_NAME || 'sopy-csrf';
+    const csrfToken = randomBytes(48).toString('hex');
+    res.cookie(csrfCookieName, csrfToken, {
+      httpOnly: false,
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
+      maxAge: refreshMaxAge,
+      path: '/',
+    });
+
+    return { success: true, token: accessToken, user };
   }
 
   @Post('login')
@@ -109,10 +159,11 @@ export class AuthController {
       7 * 24 * 60 * 60 * 1000;
 
     const accessCookieName = process.env.AUTH_COOKIE_NAME || 'sopy-auth-token';
+    const sameSite = (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax';
     res.cookie(accessCookieName, accessToken, {
       httpOnly: true,
-      secure,
-      sameSite: 'lax',
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
       maxAge: accessMaxAge,
       path: '/',
     });
@@ -121,8 +172,8 @@ export class AuthController {
       process.env.AUTH_REFRESH_COOKIE_NAME || 'sopy-refresh-token';
     res.cookie(refreshCookieName, refreshToken, {
       httpOnly: true,
-      secure,
-      sameSite: 'lax',
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
       maxAge: refreshMaxAge,
       path: '/',
     });
@@ -131,8 +182,8 @@ export class AuthController {
     const csrfToken = randomBytes(48).toString('hex');
     res.cookie(csrfCookieName, csrfToken, {
       httpOnly: false,
-      secure,
-      sameSite: 'lax',
+      secure: sameSite === 'none' ? true : secure,
+      sameSite,
       maxAge: refreshMaxAge,
       path: '/',
     });
@@ -180,11 +231,11 @@ export class AuthController {
 
       const accessCookieName =
         process.env.AUTH_COOKIE_NAME || 'sopy-auth-token';
+      const sameSite = (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax';
       res.cookie(accessCookieName, accessToken, {
         httpOnly: true,
-        secure,
-        sameSite:
-          (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax',
+        secure: sameSite === 'none' ? true : secure,
+        sameSite,
         maxAge: accessMaxAge,
         path: '/',
       });
@@ -193,9 +244,8 @@ export class AuthController {
         process.env.AUTH_REFRESH_COOKIE_NAME || 'sopy-refresh-token';
       res.cookie(refreshCookieNameEnv, newRefreshToken, {
         httpOnly: true,
-        secure,
-        sameSite:
-          (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax',
+        secure: sameSite === 'none' ? true : secure,
+        sameSite,
         maxAge: refreshMaxAge,
         path: '/',
       });
@@ -204,9 +254,8 @@ export class AuthController {
       const csrfToken = randomBytes(48).toString('hex');
       res.cookie(csrfCookieName, csrfToken, {
         httpOnly: false,
-        secure,
-        sameSite:
-          (process.env.COOKIE_SAMESITE as 'lax' | 'strict' | 'none') || 'lax',
+        secure: sameSite === 'none' ? true : secure,
+        sameSite,
         maxAge: refreshMaxAge,
         path: '/',
       });

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { ConflictException, Injectable, UnauthorizedException } from '@nestjs/common';
 import { PrismaService } from '../../prisma/prisma.service';
-import bcrypt from 'bcryptjs';
+import * as bcrypt from 'bcryptjs';
 import * as jwt from 'jsonwebtoken';
+import { RegisterDto } from './dto/register.dto';
 
 type JWTPayload = { id: string; email: string; roleId?: string };
 type ValidatedUser = {
@@ -24,10 +25,7 @@ export class AuthService {
     });
     if (!user) return null;
 
-    const compareFn = (
-      bcrypt as { compare: (data: string, hash: string) => Promise<boolean> }
-    ).compare;
-    const valid = await compareFn(password, String(user.passwordHash));
+    const valid = await bcrypt.compare(password, String(user.passwordHash));
     if (!valid) return null;
 
     // remove sensitive fields and include role names
@@ -60,6 +58,38 @@ export class AuthService {
       expiresIn: refreshExpiresIn,
     } as jwt.SignOptions);
     return { accessToken, refreshToken, user };
+  }
+
+  async register(dto: RegisterDto) {
+    const existing = await this.prisma.user.findUnique({ where: { email: dto.email } });
+    if (existing) throw new ConflictException('Email already registered');
+
+    const saltRounds = Number(process.env.PASSWORD_SALT_ROUNDS || 10);
+    const passwordHash = await bcrypt.hash(dto.password, saltRounds);
+
+    const role = await this.prisma.role.findFirst({
+      where: { name: { equals: 'USER', mode: 'insensitive' } },
+    });
+
+    const created = await this.prisma.user.create({
+      data: {
+        email: dto.email,
+        name: dto.name,
+        passwordHash,
+        roleId: role?.id ?? undefined,
+      },
+      include: { role: true },
+    });
+
+    const safeUser = {
+      ...created,
+      role: created.role?.name,
+      roles: created.role?.name ? [created.role.name] : [],
+    } as ValidatedUser;
+
+    delete (safeUser as { passwordHash?: unknown }).passwordHash;
+
+    return this.login(safeUser);
   }
 
   async refreshTokens(refreshToken: string) {

--- a/src/modules/auth/dto/register.dto.ts
+++ b/src/modules/auth/dto/register.dto.ts
@@ -1,0 +1,23 @@
+import { IsEmail, IsOptional, IsString, MinLength } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class RegisterDto {
+  @ApiProperty({ example: 'user@example.com' })
+  @IsEmail()
+  email: string;
+
+  @ApiProperty({ minLength: 8 })
+  @IsString()
+  @MinLength(8)
+  password: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @ApiPropertyOptional({ description: 'Ubicación (texto libre)' })
+  @IsOptional()
+  @IsString()
+  location?: string;
+}


### PR DESCRIPTION
Introduce user registration flow and adjust CSRF/cookie handling.

- Add RegisterDto with validation (email, password, optional name and location).
- Implement POST /api/auth/register in AuthController: create account via AuthService.register, set access/refresh cookies and a CSRF cookie. Consolidate COOKIE_SAMESITE handling and set secure=true when sameSite is 'none'.
- Add AuthService.register: check for existing email (ConflictException), hash password, assign USER role, create user and return tokens via existing login flow.
- Simplify bcrypt usage and minor import adjustments.
- Update csrf middleware to allowlist auth mutating routes (login, register, refresh, logout, 2fa/verify) so they skip CSRF checks.

These changes add account creation, ensure cookie SameSite behavior is driven by env, and prevent CSRF blocking for auth endpoints.